### PR TITLE
Add runtime challenge toggle API

### DIFF
--- a/lib/challengeOverride.ts
+++ b/lib/challengeOverride.ts
@@ -1,0 +1,27 @@
+export type { ChallengeKey } from '../models/challenge'
+import type { ChallengeKey } from '../models/challenge'
+
+const overrides: Record<ChallengeKey, boolean | undefined> = {} as any
+
+export function setOverride (key: ChallengeKey, enabled: boolean) {
+  overrides[key] = enabled
+}
+
+export function clearOverride (key: ChallengeKey) {
+  delete overrides[key]
+}
+
+export function getOverride (key: ChallengeKey): boolean | undefined {
+  return overrides[key]
+}
+
+export function listOverrides (): Record<ChallengeKey, boolean> {
+  const result: Record<ChallengeKey, boolean> = {} as any
+  for (const k of Object.keys(overrides)) {
+    const val = overrides[k as ChallengeKey]
+    if (typeof val === 'boolean') {
+      result[k as ChallengeKey] = val
+    }
+  }
+  return result
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,6 +13,7 @@ import download from 'download'
 import crypto from 'node:crypto'
 import clarinet from 'clarinet'
 import type { Challenge } from 'data/types'
+import { getOverride } from './challengeOverride'
 
 import isHeroku from './is-heroku'
 import isDocker from './is-docker'
@@ -190,6 +191,10 @@ export function getChallengeEnablementStatus (challenge: Challenge,
   return { enabled: true, disabledBecause: null }
 }
 export function isChallengeEnabled (challenge: Challenge): boolean {
+  const override = getOverride(challenge.key)
+  if (override !== undefined) {
+    return override
+  }
   const { enabled } = getChallengeEnablementStatus(challenge)
   return enabled
 }

--- a/routes/challengeToggle.ts
+++ b/routes/challengeToggle.ts
@@ -1,0 +1,43 @@
+import express, { type Request, type Response } from 'express'
+import { challenges } from '../data/datacache'
+import * as utils from '../lib/utils'
+import { setOverride, clearOverride, type ChallengeKey } from '../lib/challengeOverride'
+
+const router = express.Router()
+
+router.get('/', (req: Request, res: Response) => {
+  const list = Object.values(challenges).map(ch => ({
+    key: ch.key,
+    name: ch.name,
+    enabled: utils.isChallengeEnabled(ch)
+  }))
+  res.json({ status: 'success', data: list })
+})
+
+router.put('/:key', (req: Request, res: Response) => {
+  const key = req.params.key as ChallengeKey
+  const challenge = challenges[key]
+  if (!challenge) {
+    res.status(404).json({ error: 'Challenge not found' })
+    return
+  }
+  if (typeof req.body.enabled !== 'boolean') {
+    res.status(400).json({ error: 'enabled flag missing' })
+    return
+  }
+  setOverride(key, req.body.enabled)
+  res.json({ key, enabled: req.body.enabled })
+})
+
+router.delete('/:key', (req: Request, res: Response) => {
+  const key = req.params.key as ChallengeKey
+  const challenge = challenges[key]
+  if (!challenge) {
+    res.status(404).json({ error: 'Challenge not found' })
+    return
+  }
+  clearOverride(key)
+  res.json({ key, enabled: utils.isChallengeEnabled(challenge) })
+})
+
+export default router

--- a/server.ts
+++ b/server.ts
@@ -124,6 +124,7 @@ import { orderHistory, allOrders, toggleDeliveryStatus } from './routes/orderHis
 import { continueCode, continueCodeFindIt, continueCodeFixIt } from './routes/continueCode'
 import { serveChallengesWithCodeSnippet, serveCodeSnippet, checkVulnLines } from './routes/vulnCodeSnippet'
 import { ensureFileIsPassed, handleZipFileUpload, checkUploadSize, checkFileType, handleXmlUpload, handleYamlUpload } from './routes/fileUpload'
+import challengeToggle from './routes/challengeToggle'
 
 const app = express()
 const server = new http.Server(app)
@@ -581,6 +582,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.put('/rest/basket/:id/coupon/:coupon', applyCoupon())
   app.get('/rest/admin/application-version', retrieveAppVersion())
   app.get('/rest/admin/application-configuration', retrieveAppConfiguration())
+  app.use('/rest/admin/challenges', challengeToggle)
   app.get('/rest/repeat-notification', repeatNotification())
   app.get('/rest/continue-code', continueCode())
   app.get('/rest/continue-code-findIt', continueCodeFindIt())


### PR DESCRIPTION
## Summary
- allow runtime control over challenge activation
- expose `/rest/admin/challenges` endpoint

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: `ng` not found)*
- `npm run build:server` *(fails: many TS errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684221b3f1608326a1dc576b0bb08c8c